### PR TITLE
Fix ModuleNotFoundError: No module named 'natsort' by importing natsort

### DIFF
--- a/scripts/gligen_pluggable.py
+++ b/scripts/gligen_pluggable.py
@@ -5,6 +5,7 @@ from torch import nn
 from ldm.modules.attention import FeedForward, SpatialTransformer
 from ldm.modules.diffusionmodules.openaimodel import UNetModel
 import itertools
+import natsort
 from natsort import natsorted
 from easing_functions import *
 import numpy as np


### PR DESCRIPTION
There are two errors I receive while launching with the extension installed:

```
Error loading script: gligen_pluggable.py
Traceback (most recent call last):
  File "C:\stable-diffusion-webui\modules\scripts.py", line 248, in load_scripts
    script_module = script_loading.load_module(scriptfile.path)
  File "C:\stable-diffusion-webui\modules\script_loading.py", line 11, in load_module
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\stable-diffusion-webui\extensions\sd_webui_gligen\scripts\gligen_pluggable.py", line 8, in <module>
    import natsort
ModuleNotFoundError: No module named 'natsort'

Error loading script: gligen_ui.py
Traceback (most recent call last):
  File "C:\stable-diffusion-webui\modules\scripts.py", line 248, in load_scripts
    script_module = script_loading.load_module(scriptfile.path)
  File "C:\stable-diffusion-webui\modules\script_loading.py", line 11, in load_module
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\stable-diffusion-webui\extensions\sd_webui_gligen\scripts\gligen_ui.py", line 8, in <module>
    from scripts.gligen_pluggable import PluggableGLIGEN
  File "C:\stable-diffusion-webui\extensions\sd_webui_gligen\scripts\gligen_pluggable.py", line 8, in <module>
    import natsort
ModuleNotFoundError: No module named 'natsort'
```

This pull request attempts to resolve these errors by explicitly importing natsort before attempting to import natsorted from natsort.