### PR TITLE
Add install.py to install dependencies

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,0 +1,7 @@
+import launch
+
+if not launch.is_installed("natsort"):
+    launch.run_pip("install natsort", "requirements for gligen")
+
+if not launch.is_installed("easing_functions"):
+    launch.run_pip("install easing_functions", "requirements for gligen")


### PR DESCRIPTION
This adds an install.py file, which allows automatic1111's webui to find or install the required dependencies.

Incidentally this solves the _ModuleNotFoundError: No module named 'natsort'_ error